### PR TITLE
Dust off code for newer deps

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013, David Johnson
+Copyright (c) 2015, David Johnson, Ricky Elrod
 
 All rights reserved.
 

--- a/Snap/Snaplet/Auth/Backends/Acid.hs
+++ b/Snap/Snaplet/Auth/Backends/Acid.hs
@@ -8,10 +8,13 @@
 
 module Snap.Snaplet.Auth.Backends.Acid where
 
+import           Control.Applicative
 import           Control.Error
 import           Control.Exception hiding (Handler)
+import           Control.Monad
 import           Control.Monad.CatchIO (throw)
 import           Control.Monad.Reader (ask)
+import           Control.Monad.State
 import           Data.Acid
 import           Data.Aeson (Value, encode, decode)
 import           Data.Attoparsec.Number (Number)
@@ -21,6 +24,7 @@ import           Data.Hashable (Hashable)
 import           Data.Maybe
 import           Data.SafeCopy
 import qualified Data.Serialize as S (get, put)
+import           Data.Scientific (Scientific)
 import           Data.Text (Text, pack)
 import           Data.Time
 import           Data.Typeable (Typeable)
@@ -58,17 +62,12 @@ instance (SafeCopy a, SafeCopy b, Eq a, Hashable a) =>
 
 
 ------------------------------------------------------------------------------
-instance (SafeCopy a) => SafeCopy (V.Vector a) where
-      getCopy = contain $ fmap V.fromList safeGet
-      putCopy = contain . safePut . V.toList
-
-
-------------------------------------------------------------------------------
 deriving instance Typeable AuthUser
 
 
 ------------------------------------------------------------------------------
 $(deriveSafeCopy 0 'base ''Number)
+$(deriveSafeCopy 0 'base ''Scientific)
 $(deriveSafeCopy 0 'base ''Value)
 $(deriveSafeCopy 0 'base ''Password)
 $(deriveSafeCopy 0 'base ''Role)

--- a/snaplet-auth-acid.cabal
+++ b/snaplet-auth-acid.cabal
@@ -1,7 +1,7 @@
 Name:                snaplet-auth-acid
-Version:             0.0.1
+Version:             0.1.0
 Synopsis:            Provides an Acid-State backend for the Auth Snaplet
-Description:         Project Description Here
+Description:         Provides an Acid-State backend for the Auth Snaplet
 License:             BSD3
 license-file:        LICENSE
 Author:              Ben Doyle
@@ -17,23 +17,24 @@ Library
     base >= 4 && < 5,
     acid-state >= 0.12.1,
     MonadCatchIO-transformers >= 0.2      && < 0.4,
-    aeson                     >= 0.6      && < 0.7,
-    attoparsec                >= 0.10     && < 0.11,
+    aeson                     >= 0.6      && < 0.10,
+    attoparsec                >= 0.10     && < 0.14,
     cereal                    >= 0.3      && < 0.5,
     clientsession             >= 0.8      && < 0.10,
-    errors                    >= 1.4      && < 1.5,
+    errors                    >= 1.4      && < 3,
     hashable                  (>= 1.1 && < 1.2) || (>= 1.2.0.6 && <1.3),
     mtl                       >  2.1      && < 3,
-    filepath                  >= 1.1      && < 1.4,
+    filepath                  >= 1.1      && < 1.5,
     directory                 >= 1.0      && < 1.3,
-    lens                      >= 3.7.6    && < 3.10,
+    lens                      >= 3.7.6    && < 5,
     snap-core                 >= 0.9      && < 0.11,
-    safecopy >= 0.8.2,
-    snap >= 0.13.0.3,
-    text >= 0.11 && < 0.12,
-    time >= 1.1 && < 1.5,
-    unordered-containers >= 0.1.4 && < 0.3,
-    vector >= 0.7.1 && < 0.11
+    safecopy                  >= 0.8.2,
+    scientific                >= 0.3      && < 0.4,
+    snap                      >= 0.13.0.3,
+    text                      >= 0.11     && < 2,
+    time                      >= 1.1      && < 1.5,
+    unordered-containers      >= 0.1.4    && < 0.3,
+    vector                    >= 0.7.1    && < 0.11
 source-repository head
   type:     git
   location: https://github.com/dmjio/snaplet-auth-acid.git


### PR DESCRIPTION
- Bump a bunch of deps
- Nuke a duplicate instance provided by newer deps
- `deriveSafeCopy` for `Scientific` (for newer `aeson`)